### PR TITLE
removes various un-used imports per linter review

### DIFF
--- a/spec/arrays/_compact.js
+++ b/spec/arrays/_compact.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _compact from '../../src/arrays/_compact'
 
 describe('_compact', function() {
@@ -14,9 +14,10 @@ describe('_compact', function() {
 
   it('_compact() returns array without falsy elements', function() {
     let anArray = [
-      1, undefined, [2], false, {key: '3'}, null, '4', 0, 5, NaN, 6, ''
+      1, undefined, [2], false, { key: '3' },
+      null, '4', 0, 5, NaN, 6, ''
     ]
-    expect(_compact(anArray)).to.deep.equal([1, [2], {key: '3'}, '4', 5, 6])
+    expect(_compact(anArray)).to.deep.equal([1, [2], { key: '3' }, '4', 5, 6])
   })
   it('_compact() returns undefined when given a sparse array', function() {
     const anArray = []
@@ -32,7 +33,7 @@ describe('_compact', function() {
     expect(_compact(nonArray)).to.be.undefined
   })
   it('_compact() returns undefined when given a nonarray object', function() {
-    const nonArray = {key: 1}
+    const nonArray = { key: 1 }
     expect(_compact(nonArray)).to.be.undefined
   })
 

--- a/spec/arrays/_difference.js
+++ b/spec/arrays/_difference.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _difference from '../../src/arrays/_difference'
 
 describe('_difference', function() {
@@ -30,10 +30,9 @@ describe('_difference', function() {
       function() {
         expect(
           _difference(
-            [1, -33, 2, 1, - Infinity, 'c'], [2, 'b', 'c', 1],
-            [undefined, 2, 1, 7]
+            [1, -33, 2, 1, -Infinity, 'c'], [2, 'b', 'c', 1], [undefined, 2, 1, 7]
           )
-        ).to.deep.equal([-33, - Infinity])
+        ).to.deep.equal([-33, -Infinity])
       }
     )
     it(
@@ -71,7 +70,7 @@ describe('_difference', function() {
     it(
       '_difference() returns undefined when any argument contains an object',
       function() {
-        expect(_difference(['a'], [1, 2, {a: 1, b: 2}])).to.be.undefined
+        expect(_difference(['a'], [1, 2, { a: 1, b: 2 }])).to.be.undefined
       }
     )
     it(
@@ -83,14 +82,14 @@ describe('_difference', function() {
     it(
       '_difference() returns undefined when any argument contains a function',
       function() {
-        const fn = function() {return 'hello'}
+        const fn = function() { return 'hello' }
         expect(_difference([1, 2, 3, fn, 4, 5], [2, 3, 4])).to.be.undefined
       }
     )
     it(
       '_difference() returns undefined when any argument is not an array',
       function() {
-        const fn = function() {return 'hello'}
+        const fn = function() { return 'hello' }
         expect(_difference(1, [2, 3])).to.be.undefined
         expect(_difference([3, 4], 3)).to.be.undefined
         expect(_difference([3, 4], '3')).to.be.undefined

--- a/spec/arrays/_first.js
+++ b/spec/arrays/_first.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _first from '../../src/arrays/_first'
 
 describe('_first', function() {
@@ -27,7 +27,7 @@ describe('_first', function() {
     })
     it('_first() with a -infinity n argument returns undefined', function() {
       const emptyArray = []
-      expect(_first(emptyArray, - Infinity)).to.be.undefined
+      expect(_first(emptyArray, -Infinity)).to.be.undefined
       expect(_first(emptyArray, Number.NEGATIVE_INFINITY)).to.be.undefined
     })
     it('_first() with n === 0 returns undefined', function() {
@@ -38,54 +38,83 @@ describe('_first', function() {
 
   context('nonempty array', function() {
     it('_first() with no n argument returns first element', function() {
-      let anArray = [undefined, [3], [4, 5], '6', {item: 7, thing: 8}]
+      let anArray = [undefined, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_first(anArray)).to.equal(undefined)
-      anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_first(anArray)).to.equal(2)
     })
     it(
       '_first() with 1 < n < length returns array of first n elements',
       function() {
-        const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+        const anArray = [2, [3],
+          [4, 5], '6', { item: 7, thing: 8 }
+        ]
         expect(_first(anArray, 2)).to.deep.equal([2, [3]])
-        expect(_first(anArray, 3)).to.deep.equal([2, [3], [4, 5]])
-        expect(_first(anArray, 4)).to.deep.equal([2, [3], [4, 5], '6'])
+        expect(_first(anArray, 3)).to.deep.equal([2, [3],
+          [4, 5]
+        ])
+        expect(_first(anArray, 4)).to.deep.equal([2, [3],
+          [4, 5], '6'
+        ])
         expect(_first(anArray, 5)).to.deep.equal(
-          [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+          [2, [3],
+            [4, 5], '6', { item: 7, thing: 8 }
+          ]
         )
       }
     )
     it(
-      '_first() with n > length returns whole array', function() {
-        const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      '_first() with n > length returns whole array',
+      function() {
+        const anArray = [2, [3],
+          [4, 5], '6', { item: 7, thing: 8 }
+        ]
         expect(_first(anArray, 6))
-          .to.deep.equal([2, [3], [4, 5], '6', {item: 7, thing: 8}])
+          .to.deep.equal([2, [3],
+            [4, 5], '6', { item: 7, thing: 8 }
+          ])
       }
     )
     it('_first() with a negative n argument returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_first(anArray, -5)).to.be.undefined
     })
     it('_first() with a +infinity n argument returns the array', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_first(anArray, Infinity)).to.deep.equal(anArray)
       expect(_first(anArray, Number.POSITIVE_INFINITY)).to.deep.equal(anArray)
     })
     it('_first() with a -infinity n argument returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
-      expect(_first(anArray, - Infinity)).to.be.undefined
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
+      expect(_first(anArray, -Infinity)).to.be.undefined
       expect(_first(anArray, Number.NEGATIVE_INFINITY)).to.be.undefined
     })
     it('_first() with n === 0 returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_first(anArray, 0)).to.be.undefined
     })
     it('_first() with non-integer n returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_first(anArray, 1.5)).to.be.undefined
     })
     it('_first() with non-number n returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_first(anArray, '2')).to.be.undefined
     })
   })
@@ -109,7 +138,7 @@ describe('_first', function() {
       expect(_first(nonArray)).to.be.undefined
     })
     it('_first() with positive n argument returns undefined', function() {
-      const nonArray = {item: 7, thing: 8}
+      const nonArray = { item: 7, thing: 8 }
       expect(_first(nonArray, 1)).to.be.undefined
     })
     it('_first() with negative n argument returns undefined', function() {

--- a/spec/arrays/_flatten.js
+++ b/spec/arrays/_flatten.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _flatten from '../../src/arrays/_flatten'
 
 describe('_flatten', function() {
@@ -15,7 +15,8 @@ describe('_flatten', function() {
     })
 
     it(
-      '_flatten() returns a copy of a 1-level array', function() {
+      '_flatten() returns a copy of a 1-level array',
+      function() {
         let anArray = [1, 2, 3]
         expect(_flatten(anArray, true)).to.deep.equal([1, 2, 3])
       }
@@ -31,17 +32,27 @@ describe('_flatten', function() {
       '_flatten() converts a complex 2-level array to a 1-level array',
       function() {
         let anArray = [
-          1, [2, 3], undefined, [4], [], {key: '5'}, null, 'string', NaN, ''
+          1, [2, 3], undefined, [4],
+          [], { key: '5' },
+          null, 'string', NaN, ''
         ]
         expect(_flatten(anArray, true)).to.deep.equal([
-          1, 2, 3, undefined, 4, {key: '5'}, null, 'string', NaN, ''
+          1, 2, 3, undefined, 4, { key: '5' },
+          null, 'string', NaN, ''
         ])
       }
     )
     it('_flatten() converts a 3-level array to a 2-level array', function() {
-      let anArray = [1, [2, [3]], [4, [5, '6']], [[]]]
+      let anArray = [1, [2, [3]],
+        [4, [5, '6']],
+        [
+          []
+        ]
+      ]
       expect(_flatten(anArray, true))
-        .to.deep.equal([1, 2, [3], 4, [5, '6'], []])
+        .to.deep.equal([1, 2, [3], 4, [5, '6'],
+          []
+        ])
     })
     it('_flatten() returns undefined when given a sparse array', function() {
       const anArray = []
@@ -57,7 +68,7 @@ describe('_flatten', function() {
       expect(_flatten(nonArray, true)).to.be.undefined
     })
     it('_flatten() returns undefined when given a nonarray object', function() {
-      const nonArray = {key: 1}
+      const nonArray = { key: 1 }
       expect(_flatten(nonArray, true)).to.be.undefined
     })
 
@@ -72,14 +83,22 @@ describe('_flatten', function() {
 
     it('_flatten() converts a 2-level array to a 1-level array', function() {
       let anArray = [
-        1, [2, 3], undefined, [4], [], {key: '5'}, null, 'string', NaN, ''
+        1, [2, 3], undefined, [4],
+        [], { key: '5' },
+        null, 'string', NaN, ''
       ]
       expect(_flatten(anArray, false)).to.deep.equal([
-        1, 2, 3, undefined, 4, {key: '5'}, null, 'string', NaN, ''
+        1, 2, 3, undefined, 4, { key: '5' },
+        null, 'string', NaN, ''
       ])
     })
     it('_flatten() converts a 3-level array to a 1-level array', function() {
-      let anArray = [1, [2, [3]], [4, [5, '6']], [[]]]
+      let anArray = [1, [2, [3]],
+        [4, [5, '6']],
+        [
+          []
+        ]
+      ]
       expect(_flatten(anArray, false))
         .to.deep.equal([1, 2, 3, 4, 5, '6'])
     })
@@ -97,7 +116,7 @@ describe('_flatten', function() {
       expect(_flatten(nonArray, false)).to.be.undefined
     })
     it('_flatten() returns undefined when given a nonarray object', function() {
-      const nonArray = {key: 1}
+      const nonArray = { key: 1 }
       expect(_flatten(nonArray, false)).to.be.undefined
     })
 
@@ -112,14 +131,22 @@ describe('_flatten', function() {
 
     it('_flatten() converts a 2-level array to a 1-level array', function() {
       let anArray = [
-        1, [2, 3], undefined, [4], [], {key: '5'}, null, 'string', NaN, ''
+        1, [2, 3], undefined, [4],
+        [], { key: '5' },
+        null, 'string', NaN, ''
       ]
       expect(_flatten(anArray)).to.deep.equal([
-        1, 2, 3, undefined, 4, {key: '5'}, null, 'string', NaN, ''
+        1, 2, 3, undefined, 4, { key: '5' },
+        null, 'string', NaN, ''
       ])
     })
     it('_flatten() converts a 3-level array to a 1-level array', function() {
-      let anArray = [1, [2, [3]], [4, [5, '6']], [[]]]
+      let anArray = [1, [2, [3]],
+        [4, [5, '6']],
+        [
+          []
+        ]
+      ]
       expect(_flatten(anArray))
         .to.deep.equal([1, 2, 3, 4, 5, '6'])
     })
@@ -137,7 +164,7 @@ describe('_flatten', function() {
       expect(_flatten(nonArray)).to.be.undefined
     })
     it('_flatten() returns undefined when given a nonarray object', function() {
-      const nonArray = {key: 1}
+      const nonArray = { key: 1 }
       expect(_flatten(nonArray)).to.be.undefined
     })
 

--- a/spec/arrays/_initial.js
+++ b/spec/arrays/_initial.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _initial from '../../src/arrays/_initial'
 
 describe('_initial', function() {
@@ -27,7 +27,7 @@ describe('_initial', function() {
     })
     it('_initial() with a -infinity n argument returns undefined', function() {
       const emptyArray = []
-      expect(_initial(emptyArray, - Infinity)).to.be.undefined
+      expect(_initial(emptyArray, -Infinity)).to.be.undefined
       expect(_initial(emptyArray, Number.NEGATIVE_INFINITY)).to.be.undefined
     })
     it('_initial() with n === 0 returns undefined', function() {
@@ -38,52 +38,79 @@ describe('_initial', function() {
 
   context('nonempty array', function() {
     it('_initial() with no n returns an array without the last element', function() {
-      const array0 = [undefined, [3], [4, 5], '6', {item: 7, thing: 8}]
-      expect(_initial(array0)).to.deep.equal([undefined, [3], [4, 5], '6'])
-      const array1 = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
-      expect(_initial(array1)).to.deep.equal([2, [3], [4, 5], '6'])
+      const array0 = [undefined, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
+      expect(_initial(array0)).to.deep.equal([undefined, [3],
+        [4, 5], '6'
+      ])
+      const array1 = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
+      expect(_initial(array1)).to.deep.equal([2, [3],
+        [4, 5], '6'
+      ])
     })
     it(
       '_initial() with 1 < n < length returns array of all but last n elements',
       function() {
-        const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
-        expect(_initial(anArray, 2)).to.deep.equal([2, [3], [4, 5]])
+        const anArray = [2, [3],
+          [4, 5], '6', { item: 7, thing: 8 }
+        ]
+        expect(_initial(anArray, 2)).to.deep.equal([2, [3],
+          [4, 5]
+        ])
         expect(_initial(anArray, 3)).to.deep.equal([2, [3]])
         expect(_initial(anArray, 4)).to.deep.equal([2])
         expect(_initial(anArray, 5)).to.deep.equal([])
       }
     )
     it(
-      '_initial() with n > length returns an empty array', function() {
-        const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      '_initial() with n > length returns an empty array',
+      function() {
+        const anArray = [2, [3],
+          [4, 5], '6', { item: 7, thing: 8 }
+        ]
         expect(_initial(anArray, 6))
           .to.deep.equal([])
       }
     )
     it('_initial() with a negative n argument returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_initial(anArray, -5)).to.be.undefined
     })
     it('_initial() with a +infinity n returns an empty array', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_initial(anArray, Infinity)).to.deep.equal([])
       expect(_initial(anArray, Number.POSITIVE_INFINITY)).to.deep.equal([])
     })
     it('_initial() with a -infinity n argument returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
-      expect(_initial(anArray, - Infinity)).to.be.undefined
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
+      expect(_initial(anArray, -Infinity)).to.be.undefined
       expect(_initial(anArray, Number.NEGATIVE_INFINITY)).to.be.undefined
     })
     it('_initial() with n === 0 returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_initial(anArray, 0)).to.be.undefined
     })
     it('_initial() with non-integer n returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_initial(anArray, 1.5)).to.be.undefined
     })
     it('_initial() with non-number n returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_initial(anArray, '2')).to.be.undefined
     })
   })
@@ -107,7 +134,7 @@ describe('_initial', function() {
       expect(_initial(nonArray)).to.be.undefined
     })
     it('_initial() with object and positive n returns undefined', function() {
-      const nonArray = {item: 7, thing: 8}
+      const nonArray = { item: 7, thing: 8 }
       expect(_initial(nonArray, 1)).to.be.undefined
     })
     it('_initial() with string and negative n returns undefined', function() {

--- a/spec/arrays/_intersection.js
+++ b/spec/arrays/_intersection.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _intersection from '../../src/arrays/_intersection'
 
 describe('_intersection', function() {
@@ -28,7 +28,7 @@ describe('_intersection', function() {
     })
     it('_intersection() returns the intersection of 3 arrays', function() {
       expect(
-        _intersection([1, 2, 1, 'c'], [2, 'b', 'c', 1], [undefined, 2, 1, 7]))
+          _intersection([1, 2, 1, 'c'], [2, 'b', 'c', 1], [undefined, 2, 1, 7]))
         .to.deep.equal([1, 2])
     })
     it(
@@ -66,7 +66,7 @@ describe('_intersection', function() {
     it(
       '_intersection() returns undefined when any argument contains an object',
       function() {
-        expect(_intersection(['a'], [1, 2, {a: 1, b: 2}])).to.be.undefined
+        expect(_intersection(['a'], [1, 2, { a: 1, b: 2 }])).to.be.undefined
       }
     )
     it(
@@ -78,14 +78,14 @@ describe('_intersection', function() {
     it(
       '_intersection() returns undefined when any argument contains a function',
       function() {
-        const fn = function() {return 'hello'}
+        const fn = function() { return 'hello' }
         expect(_intersection([1, 2, 3, fn, 4, 5], [2, 3, 4])).to.be.undefined
       }
     )
     it(
       '_intersection() returns undefined when any argument is not an array',
       function() {
-        const fn = function() {return 'hello'}
+        const fn = function() { return 'hello' }
         expect(_intersection(1, [1, 2, 3])).to.be.undefined
         expect(_intersection([3, 4], 3)).to.be.undefined
         expect(_intersection([3, 4], '3')).to.be.undefined

--- a/spec/arrays/_last.js
+++ b/spec/arrays/_last.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _last from '../../src/arrays/_last'
 
 describe('_last', function() {
@@ -27,7 +27,7 @@ describe('_last', function() {
     })
     it('_last() with a -infinity n argument returns undefined', function() {
       const emptyArray = []
-      expect(_last(emptyArray, - Infinity)).to.be.undefined
+      expect(_last(emptyArray, -Infinity)).to.be.undefined
       expect(_last(emptyArray, Number.NEGATIVE_INFINITY)).to.be.undefined
     })
     it('_last() with n === 0 returns undefined', function() {
@@ -38,55 +38,86 @@ describe('_last', function() {
 
   context('nonempty array', function() {
     it('_last() with no n argument returns last element', function() {
-      let anArray = [undefined, [3], [4, 5], '6', {item: 7, thing: 8}]
-      expect(_last(anArray)).to.deep.equal({item: 7, thing: 8})
-      anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}, undefined]
+      let anArray = [undefined, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
+      expect(_last(anArray)).to.deep.equal({ item: 7, thing: 8 })
+      anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 },
+        undefined
+      ]
       expect(_last(anArray)).to.equal(undefined)
     })
     it(
       '_last() with 1 < n < length returns array of last n elements',
       function() {
-        const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
-        expect(_last(anArray, 2)).to.deep.equal(['6', {item: 7, thing: 8}])
+        const anArray = [2, [3],
+          [4, 5], '6', { item: 7, thing: 8 }
+        ]
+        expect(_last(anArray, 2)).to.deep.equal(['6', { item: 7, thing: 8 }])
         expect(_last(anArray, 3))
-          .to.deep.equal([[4, 5], '6', {item: 7, thing: 8}])
+          .to.deep.equal([
+            [4, 5], '6', { item: 7, thing: 8 }
+          ])
         expect(_last(anArray, 4))
-          .to.deep.equal([[3], [4, 5], '6', {item: 7, thing: 8}])
+          .to.deep.equal([
+            [3],
+            [4, 5], '6', { item: 7, thing: 8 }
+          ])
         expect(_last(anArray, 5))
-          .to.deep.equal([2, [3], [4, 5], '6', {item: 7, thing: 8}])
+          .to.deep.equal([2, [3],
+            [4, 5], '6', { item: 7, thing: 8 }
+          ])
       }
     )
     it(
-      '_last() with n > length returns whole array', function() {
-        const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      '_last() with n > length returns whole array',
+      function() {
+        const anArray = [2, [3],
+          [4, 5], '6', { item: 7, thing: 8 }
+        ]
         expect(_last(anArray, 6))
-          .to.deep.equal([2, [3], [4, 5], '6', {item: 7, thing: 8}])
+          .to.deep.equal([2, [3],
+            [4, 5], '6', { item: 7, thing: 8 }
+          ])
       }
     )
     it('_last() with a negative n argument returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_last(anArray, -5)).to.be.undefined
     })
     it('_last() with a +infinity n argument returns the array', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_last(anArray, Infinity)).to.deep.equal(anArray)
       expect(_last(anArray, Number.POSITIVE_INFINITY)).to.deep.equal(anArray)
     })
     it('_last() with a -infinity n argument returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
-      expect(_last(anArray, - Infinity)).to.be.undefined
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
+      expect(_last(anArray, -Infinity)).to.be.undefined
       expect(_last(anArray, Number.NEGATIVE_INFINITY)).to.be.undefined
     })
     it('_last() with n === 0 returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_last(anArray, 0)).to.be.undefined
     })
     it('_last() with non-integer n returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_last(anArray, 1.5)).to.be.undefined
     })
     it('_last() with non-number n returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_last(anArray, '2')).to.be.undefined
     })
   })
@@ -110,7 +141,7 @@ describe('_last', function() {
       expect(_last(nonArray)).to.be.undefined
     })
     it('_last() with positive n argument returns undefined', function() {
-      const nonArray = {item: 7, thing: 8}
+      const nonArray = { item: 7, thing: 8 }
       expect(_last(nonArray, 1)).to.be.undefined
     })
     it('_last() with negative n argument returns undefined', function() {

--- a/spec/arrays/_last_index_of.js
+++ b/spec/arrays/_last_index_of.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _lastIndexOf from '../../src/arrays/_last_index_of'
 
 describe('_lastIndexOf', function() {
@@ -31,11 +31,11 @@ describe('_lastIndexOf', function() {
         .to.equal(4)
     })
     it('matches Infinity instances', function() {
-      expect(_lastIndexOf(['b', 7, - Infinity, 'stuf'], - Infinity))
+      expect(_lastIndexOf(['b', 7, -Infinity, 'stuf'], -Infinity))
         .to.equal(2)
     })
     it('matches NaN instances', function() {
-      expect(_lastIndexOf([NaN, 7, - Infinity, NaN, 'stuf'], - Infinity))
+      expect(_lastIndexOf([NaN, 7, -Infinity, NaN, 'stuf'], -Infinity))
         .to.equal(2)
     })
   })
@@ -82,7 +82,7 @@ describe('_lastIndexOf', function() {
       expect(_lastIndexOf('[1, 2]', 0)).to.be.undefined
     })
     it('with argument 0 an object returns undefined', function() {
-      expect(_lastIndexOf({a: 1})).to.be.undefined
+      expect(_lastIndexOf({ a: 1 })).to.be.undefined
     })
     it('with argument 0 null returns undefined', function() {
       expect(_lastIndexOf(null)).to.be.undefined
@@ -109,7 +109,7 @@ describe('_lastIndexOf', function() {
       expect(_lastIndexOf([1, 2, [3, 4], 5], 2)).to.be.undefined
     })
     it('with argument 0 including an object returns undefined', function() {
-      expect(_lastIndexOf([1, 2, {a: 3}, 5], 2, 1)).to.be.undefined
+      expect(_lastIndexOf([1, 2, { a: 3 }, 5], 2, 1)).to.be.undefined
     })
   })
 

--- a/spec/arrays/_rest.js
+++ b/spec/arrays/_rest.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _rest from '../../src/arrays/_rest'
 
 describe('_rest', function() {
@@ -27,7 +27,7 @@ describe('_rest', function() {
     })
     it('_rest() with a -infinity n argument returns undefined', function() {
       const emptyArray = []
-      expect(_rest(emptyArray, - Infinity)).to.be.undefined
+      expect(_rest(emptyArray, -Infinity)).to.be.undefined
       expect(_rest(emptyArray, Number.NEGATIVE_INFINITY)).to.be.undefined
     })
     it('_rest() with n === 0 returns undefined', function() {
@@ -38,52 +38,84 @@ describe('_rest', function() {
 
   context('nonempty array', function() {
     it('_rest() with no n returns an array without first element', function() {
-      const array0 = [undefined, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const array0 = [undefined, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_rest(array0))
-        .to.deep.equal([[3], [4, 5], '6', {item: 7, thing: 8}])
-      const array1 = [[3], [4, 5], '6', {item: 7, thing: 8}, undefined]
+        .to.deep.equal([
+          [3],
+          [4, 5], '6', { item: 7, thing: 8 }
+        ])
+      const array1 = [
+        [3],
+        [4, 5], '6', { item: 7, thing: 8 },
+        undefined
+      ]
       expect(_rest(array1))
-        .to.deep.equal([[4, 5], '6', {item: 7, thing: 8}, undefined])
+        .to.deep.equal([
+          [4, 5], '6', { item: 7, thing: 8 },
+          undefined
+        ])
     })
     it(
       '_rest() with 0 ≤ n < length returns array of nth through last element',
       function() {
-        const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+        const anArray = [2, [3],
+          [4, 5], '6', { item: 7, thing: 8 }
+        ]
         expect(_rest(anArray, 0))
-          .to.deep.equal([2, [3], [4, 5], '6', {item: 7, thing: 8}])
+          .to.deep.equal([2, [3],
+            [4, 5], '6', { item: 7, thing: 8 }
+          ])
         expect(_rest(anArray, 1))
-          .to.deep.equal([[3], [4, 5], '6', {item: 7, thing: 8}])
-        expect(_rest(anArray, 4)).to.deep.equal([{item: 7, thing: 8}])
+          .to.deep.equal([
+            [3],
+            [4, 5], '6', { item: 7, thing: 8 }
+          ])
+        expect(_rest(anArray, 4)).to.deep.equal([{ item: 7, thing: 8 }])
         expect(_rest(anArray, 5)).to.deep.equal([])
       }
     )
     it(
-      '_rest() with n ≥ length returns an empty array', function() {
-        const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      '_rest() with n ≥ length returns an empty array',
+      function() {
+        const anArray = [2, [3],
+          [4, 5], '6', { item: 7, thing: 8 }
+        ]
         expect(_rest(anArray, 6))
           .to.deep.equal([])
       }
     )
     it('_rest() with a negative n argument returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_rest(anArray, -5)).to.be.undefined
     })
     it('_rest() with a +infinity n returns an empty array', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_rest(anArray, Infinity)).to.deep.equal([])
       expect(_rest(anArray, Number.POSITIVE_INFINITY)).to.deep.equal([])
     })
     it('_rest() with a -infinity n argument returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
-      expect(_rest(anArray, - Infinity)).to.be.undefined
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
+      expect(_rest(anArray, -Infinity)).to.be.undefined
       expect(_rest(anArray, Number.NEGATIVE_INFINITY)).to.be.undefined
     })
     it('_rest() with non-integer n returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_rest(anArray, 1.5)).to.be.undefined
     })
     it('_rest() with non-number n returns undefined', function() {
-      const anArray = [2, [3], [4, 5], '6', {item: 7, thing: 8}]
+      const anArray = [2, [3],
+        [4, 5], '6', { item: 7, thing: 8 }
+      ]
       expect(_rest(anArray, '2')).to.be.undefined
     })
   })
@@ -107,7 +139,7 @@ describe('_rest', function() {
       expect(_rest(nonArray)).to.be.undefined
     })
     it('_rest() with object and positive n returns undefined', function() {
-      const nonArray = {item: 7, thing: 8}
+      const nonArray = { item: 7, thing: 8 }
       expect(_rest(nonArray, 1)).to.be.undefined
     })
     it('_rest() with string and negative n returns undefined', function() {

--- a/spec/arrays/_union.js
+++ b/spec/arrays/_union.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _union from '../../src/arrays/_union'
 
 describe('_union', function() {
@@ -58,7 +58,7 @@ describe('_union', function() {
     it(
       '_union() returns undefined when any argument contains an object',
       function() {
-        expect(_union(['a'], [1, 2, {a: 1, b: 2}])).to.be.undefined
+        expect(_union(['a'], [1, 2, { a: 1, b: 2 }])).to.be.undefined
       }
     )
     it(
@@ -70,14 +70,14 @@ describe('_union', function() {
     it(
       '_union() returns undefined when any argument contains a function',
       function() {
-        const fn = function() {return 'hello'}
+        const fn = function() { return 'hello' }
         expect(_union([1, 2, 3, fn, 4, 5], [2, 3, 4])).to.be.undefined
       }
     )
     it(
       '_union() returns undefined when any argument is not an array',
       function() {
-        const fn = function() {return 'hello'}
+        const fn = function() { return 'hello' }
         expect(_union(1, [1, 2, 3])).to.be.undefined
         expect(_union([3, 4], 3)).to.be.undefined
         expect(_union([3, 4], '3')).to.be.undefined

--- a/spec/arrays/_without.js
+++ b/spec/arrays/_without.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _without from '../../src/arrays/_without'
 
 describe('_without', function() {
@@ -55,9 +55,9 @@ describe('_without', function() {
       expect(_without(anArray, [3])).to.be.undefined
     })
     it('_without() returns undefined when array contains an object', function() {
-      const anArray = [1, 2, 'a', {a: 1}]
+      const anArray = [1, 2, 'a', { a: 1 }]
       expect(_without(anArray, 1, 2)).to.be.undefined
-      expect(_without(anArray, {a: 1})).to.be.undefined
+      expect(_without(anArray, { a: 1 })).to.be.undefined
     })
     it('_without() returns undefined when array contains null', function() {
       const anArray = [1, 2, null, 3]
@@ -65,7 +65,7 @@ describe('_without', function() {
       expect(_without(anArray, null)).to.be.undefined
     })
     it('_without() returns undefined when array contains a function', function() {
-      const fn = function() {return 'hello'}
+      const fn = function() { return 'hello' }
       const anArray = [1, 2, fn, 'a']
       expect(_without(anArray, 1, 2)).to.be.undefined
       expect(_without(anArray, fn, 2)).to.be.undefined
@@ -88,7 +88,7 @@ describe('_without', function() {
     it(
       '_without() returns undefined when argument 0 is a nonarray object',
       function() {
-        const nonArray = {key: 1}
+        const nonArray = { key: 1 }
         expect(_without(nonArray, 'key')).to.be.undefined
       })
 

--- a/spec/collections/_contains.js
+++ b/spec/collections/_contains.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _contains from '../../src/collections/_contains'
 
 describe('_contains', function() {
@@ -48,13 +48,13 @@ describe('_contains', function() {
       expect(_contains([], 'element')).to.be.false
     })
     it('returns true when given {"": "zilch", x: "stuff"} and “”', function() {
-      expect(_contains({'': 'zilch', x: 'stuff'}, '')).to.be.true
+      expect(_contains({ '': 'zilch', x: 'stuff' }, '')).to.be.true
     })
     it('returns false when given {} and “”', function() {
       expect(_contains({}, '')).to.be.false
     })
     it('returns false when given {a: 1} and NaN', function() {
-      expect(_contains({a: 1}, NaN)).to.be.false
+      expect(_contains({ a: 1 }, NaN)).to.be.false
     })
   })
 
@@ -74,14 +74,14 @@ describe('_contains', function() {
     it(
       'returns true when given {alpha: 1, beta: 2}, “beta”, and 1',
       function() {
-        expect(_contains({alpha: 1, beta: 2}, 'beta', 1)).to.be.true
+        expect(_contains({ alpha: 1, beta: 2 }, 'beta', 1)).to.be.true
       }
     )
     it(
       'returns true when given {alpha: 1, beta: 2, gamma: 3}, “beta”, and 1',
       function() {
-        expect(_contains({alpha: 1, beta: 2, gamma: 3}, 'beta', 1))
-        .to.be.true
+        expect(_contains({ alpha: 1, beta: 2, gamma: 3 }, 'beta', 1))
+          .to.be.true
       }
     )
     it('returns false when given [1, 2, "3", 10], 3, and 1', function() {
@@ -105,14 +105,14 @@ describe('_contains', function() {
     it(
       'returns true when given {"": "zilch", x: "stuff"}, “”, and 0',
       function() {
-        expect(_contains({'': 'zilch', x: 'stuff'}, '')).to.be.true
+        expect(_contains({ '': 'zilch', x: 'stuff' }, '')).to.be.true
       }
     )
     it('returns false when given {}, “”, and 0', function() {
       expect(_contains({}, '', 0)).to.be.false
     })
     it('returns false when given {a: 1}, NaN, and 0', function() {
-      expect(_contains({a: 1}, NaN, 0)).to.be.false
+      expect(_contains({ a: 1 }, NaN, 0)).to.be.false
     })
     it('returns true when given [8, undefined], undefined, and 1', function() {
       expect(_contains([8, undefined], undefined, 1)).to.be.true

--- a/spec/collections/_size.js
+++ b/spec/collections/_size.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _size from '../../src/collections/_size'
 
 describe('_size', function() {
@@ -10,7 +10,7 @@ describe('_size', function() {
     expect(_size([1, 2, '3', 10])).to.equal(4)
   })
   it('_size() returns 3 when given {a: 1, b: "2", c: [5, 6, 7]}', function() {
-    expect(_size({a: 1, b: '2', c: [5, 6, 7]})).to.equal(3)
+    expect(_size({ a: 1, b: '2', c: [5, 6, 7] })).to.equal(3)
   })
   it('_size() returns 0 when given an empty array', function() {
     expect(_size([])).to.equal(0)

--- a/spec/objects/_allKeysTest.js
+++ b/spec/objects/_allKeysTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _allKeys from '../../src/objects/_allKeys'
 

--- a/spec/objects/_cloneTest.js
+++ b/spec/objects/_cloneTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _clone from '../../src/objects/_clone'
 

--- a/spec/objects/_extendTest.js
+++ b/spec/objects/_extendTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _extend from '../../src/objects/_extend'
 

--- a/spec/objects/_hasTest.js
+++ b/spec/objects/_hasTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _has from '../../src/objects/_has'
 

--- a/spec/objects/_isArgumentsTest.js
+++ b/spec/objects/_isArgumentsTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _isArguments from '../../src/objects/_isArguments'
 

--- a/spec/objects/_isArrayTest.js
+++ b/spec/objects/_isArrayTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _isArray from '../../src/objects/_isArray'
 

--- a/spec/objects/_isEmptyTest.js
+++ b/spec/objects/_isEmptyTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _isEmpty from '../../src/objects/_isEmpty'
 

--- a/spec/objects/_isFiniteTest.js
+++ b/spec/objects/_isFiniteTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _isFinite from '../../src/objects/_isFinite'
 

--- a/spec/objects/_isNullTest.js
+++ b/spec/objects/_isNullTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _isNull from '../../src/objects/_isNull'
 

--- a/spec/objects/_isNumberTest.js
+++ b/spec/objects/_isNumberTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _isNumber from '../../src/objects/_isNumber'
 

--- a/spec/objects/_isObjectTest.js
+++ b/spec/objects/_isObjectTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _isObject from '../../src/objects/_isObject'
 

--- a/spec/objects/_isStringTest.js
+++ b/spec/objects/_isStringTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _isString from '../../src/objects/_isString'
 

--- a/spec/objects/_isUndefinedTest.js
+++ b/spec/objects/_isUndefinedTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _isUndefined from '../../src/objects/_isUndefined'
 

--- a/spec/objects/_keysTest.js
+++ b/spec/objects/_keysTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _keys from '../../src/objects/_keys'
 

--- a/spec/objects/_valuesTest.js
+++ b/spec/objects/_valuesTest.js
@@ -1,4 +1,3 @@
-import chai from 'chai'
 import { expect } from 'chai'
 import _values from '../../src/objects/_values'
 

--- a/spec/utility/_escape.js
+++ b/spec/utility/_escape.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _escape from '../../src/utility/_escape'
 
 describe('_escape', function() {
@@ -16,9 +16,9 @@ describe('_escape', function() {
     })
     it('escapes all required metacharacters', function() {
       expect(_escape('PG&E <<`electricity\'>> is "cheap"'))
-      .to.equal(
-        'PG&amp;E &lt;&lt;&#x60;electricity&#x27;&gt;&gt; is &quot;cheap&quot;'
-      )
+        .to.equal(
+          'PG&amp;E &lt;&lt;&#x60;electricity&#x27;&gt;&gt; is &quot;cheap&quot;'
+        )
     })
     it('returns a blank string if given a blank string', function() {
       expect(_escape('')).to.equal('')
@@ -48,7 +48,8 @@ describe('_escape', function() {
       }
     )
     it(
-      'returns undefined when argument 0 is null', function() {
+      'returns undefined when argument 0 is null',
+      function() {
         expect(_escape(null)).to.be.undefined
       }
     )

--- a/spec/utility/_identity.js
+++ b/spec/utility/_identity.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _identity from '../../src/utility/_identity'
 
 describe('_identity', function() {
@@ -35,10 +35,10 @@ describe('_identity', function() {
     expect(_identity({})).to.deep.equal({})
   })
   it('_identity() returns equivalent object when given an object', function() {
-    expect(_identity({a: 1, b: 2})).to.deep.equal({a: 1, b: 2})
+    expect(_identity({ a: 1, b: 2 })).to.deep.equal({ a: 1, b: 2 })
   })
   it('_identity() returns ref to same object when given an object', function() {
-    const thisObject = {a: 1, b: 2}
+    const thisObject = { a: 1, b: 2 }
     expect(_identity(thisObject)).to.equal(thisObject)
   })
   it('_identity() returns undefined when there is no argument', function() {

--- a/spec/utility/_noop.js
+++ b/spec/utility/_noop.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _noop from '../../src/utility/_noop'
 
 describe('_noop', function() {
@@ -16,7 +16,7 @@ describe('_noop', function() {
     expect(_noop([1, 2])).to.be.undefined
   })
   it('_noop() returns undefined when given {a: 1}', function() {
-    expect(_noop({a: 1})).to.be.undefined
+    expect(_noop({ a: 1 })).to.be.undefined
   })
   it('_noop() returns undefined when given undefined', function() {
     expect(_noop(undefined)).to.be.undefined

--- a/spec/utility/_now.js
+++ b/spec/utility/_now.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _now from '../../src/utility/_now'
 
 describe('_now', function() {

--- a/spec/utility/_random.js
+++ b/spec/utility/_random.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _random from '../../src/utility/_random'
 
 describe('_random', function() {
@@ -49,7 +49,8 @@ describe('_random', function() {
       }
     )
     it(
-      'returns undefined when either argument is null', function() {
+      'returns undefined when either argument is null',
+      function() {
         expect(_random(null, 20)).to.be.undefined
       }
     )

--- a/spec/utility/_unescape.js
+++ b/spec/utility/_unescape.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 import _unescape from '../../src/utility/_unescape'
 
 describe('_unescape', function() {
@@ -16,11 +16,11 @@ describe('_unescape', function() {
     })
     it('unescapes all required entities', function() {
       expect(_unescape('PG&amp;E &lt;&lt;&#x60;electricity&#x27;&gt;&gt; is &quot;cheap&quot;'))
-      .to.equal('PG&E <<`electricity\'>> is "cheap"')
+        .to.equal('PG&E <<`electricity\'>> is "cheap"')
     })
     it('unescapes all required entities if &#x60; is decimalized', function() {
       expect(_unescape('PG&amp;E &lt;&lt;&#96;electricity&#x27;&gt;&gt; is &quot;cheap&quot;'))
-      .to.equal('PG&E <<`electricity\'>> is "cheap"')
+        .to.equal('PG&E <<`electricity\'>> is "cheap"')
     })
     it('returns a blank string if given a blank string', function() {
       expect(_unescape('')).to.equal('')
@@ -50,7 +50,8 @@ describe('_unescape', function() {
       }
     )
     it(
-      'returns undefined when argument 0 is null', function() {
+      'returns undefined when argument 0 is null',
+      function() {
         expect(_unescape(null)).to.be.undefined
       }
     )


### PR DESCRIPTION
removes import chai from tests as the tests were not calling chai directly (import { expect } is what we are using from chai)